### PR TITLE
Time should be given in seconds in solve()

### DIFF
--- a/astrochem_wrapper.py
+++ b/astrochem_wrapper.py
@@ -35,7 +35,7 @@ times = np.logspace(2, 8, 128)
 abundances = []
 for time in times:
     try:
-        abundances.append(s.solve(time)['CO'])
+        abundances.append(s.solve(time * 3600 * 24 * 365)['CO'])
     except ArithmeticError as e:
         raise "Something went wrong: %s" % e
 


### PR DESCRIPTION
The Python wrapper `solve()` functions takes the time in seconds, not in years. This fixes the differences you've encountered between the command line version and the Python wrapper.